### PR TITLE
changes to work with embedded-hal 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,17 +15,14 @@ documentation = "https://docs.rs/sht4x"
 repository = "https://github.com/sirhcel/sht4x"
 readme = "README.md"
 
-exclude = [
-    "/.github/",
-    ".gitignore",
-]
+exclude = ["/.github/", ".gitignore"]
 
 
 [dependencies]
 defmt = { version = "0.3.2", optional = true }
-embedded-hal = "0.2.7"
+embedded-hal = "1.0.0"
 fixed = "1.20.0"
-sensirion-i2c = "0.2"
+sensirion-i2c = "0.3"
 
 [features]
 defmt = ["dep:defmt"]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -31,7 +31,7 @@ impl Command {
         }
     }
 
-    pub(crate) fn duration_ms(&self) -> u16 {
+    pub(crate) fn duration_ms(&self) -> u32 {
         // Values rounded up from the maximum durations given in the datasheet
         // table 4, 'System timing specifications'.
         match self {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,5 @@
-use embedded_hal::blocking::i2c::{Read, Write};
+use embedded_hal::i2c::I2c;
+use embedded_hal::i2c::SevenBitAddress;
 use sensirion_i2c::i2c;
 
 /// Error conditions from accessing SHT4x sensors.
@@ -12,12 +13,11 @@ pub enum Error<E> {
     Crc,
 }
 
-impl<E, W, R> From<i2c::Error<W, R>> for Error<E>
+impl<I, E> From<i2c::Error<I>> for Error<E>
 where
-    W: Write<Error = E>,
-    R: Read<Error = E>,
+    I: I2c<SevenBitAddress, Error = E>,
 {
-    fn from(err: i2c::Error<W, R>) -> Self {
+    fn from(err: i2c::Error<I>) -> Self {
         match err {
             i2c::Error::Crc => Error::Crc,
             i2c::Error::I2cRead(e) => Error::I2c(e),

--- a/src/sht4x.rs
+++ b/src/sht4x.rs
@@ -4,10 +4,7 @@ use crate::{
     types::{Address, HeatingDuration, HeatingPower, Measurement, Precision, SensorData},
 };
 use core::marker::PhantomData;
-use embedded_hal::blocking::{
-    delay::DelayMs,
-    i2c::{Read, Write, WriteRead},
-};
+use embedded_hal::{delay::DelayNs, i2c::I2c, i2c::SevenBitAddress};
 use sensirion_i2c::i2c;
 
 const RESPONSE_LEN: usize = 6;
@@ -48,8 +45,8 @@ impl From<Precision> for Command {
 
 impl<I, D, E> Sht4x<I, D>
 where
-    I: Read<Error = E> + Write<Error = E> + WriteRead<Error = E>,
-    D: DelayMs<u16>,
+    I: I2c<SevenBitAddress, Error = E>,
+    D: DelayNs,
 {
     /// Creates a new driver instance using the given I2C bus. It configures the default I2C
     /// address 0x44 used by most family members.


### PR DESCRIPTION
**Breaking changes**

Updated dependencies and changed it to work with embedded-hal 1.0.0. There were a  lot of changes in embedded-hal 1.0.0. I am not sure if I did this correctly. It does change the API sht4x exposes to the end-user, so this is a breaking change.