### PR TITLE
Update to `embedded-hal` 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sht4x"
 description = "Sensirion SHT4x Driver for Embedded HAL"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 authors = ["Christian Meusel <christian.meusel@posteo.de>"]
@@ -23,9 +23,9 @@ exclude = [
 
 [dependencies]
 defmt = { version = "0.3.2", optional = true }
-embedded-hal = "0.2.7"
+embedded-hal = "1.0.0"
 fixed = "1.20.0"
-sensirion-i2c = "0.2"
+sensirion-i2c = "0.3"
 
 [features]
 defmt = ["dep:defmt"]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -31,7 +31,7 @@ impl Command {
         }
     }
 
-    pub(crate) fn duration_ms(&self) -> u16 {
+    pub(crate) fn duration_ms(&self) -> u32 {
         // Values rounded up from the maximum durations given in the datasheet
         // table 4, 'System timing specifications'.
         match self {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,3 @@
-use embedded_hal::blocking::i2c::{Read, Write};
 use sensirion_i2c::i2c;
 
 /// Error conditions from accessing SHT4x sensors.
@@ -12,12 +11,11 @@ pub enum Error<E> {
     Crc,
 }
 
-impl<E, W, R> From<i2c::Error<W, R>> for Error<E>
+impl<I> From<i2c::Error<I>> for Error<I::Error>
 where
-    W: Write<Error = E>,
-    R: Read<Error = E>,
+    I: embedded_hal::i2c::I2c,
 {
-    fn from(err: i2c::Error<W, R>) -> Self {
+    fn from(err: i2c::Error<I>) -> Self {
         match err {
             i2c::Error::Crc => Error::Crc,
             i2c::Error::I2cRead(e) => Error::I2c(e),

--- a/src/sht4x.rs
+++ b/src/sht4x.rs
@@ -4,10 +4,7 @@ use crate::{
     types::{Address, HeatingDuration, HeatingPower, Measurement, Precision, SensorData},
 };
 use core::marker::PhantomData;
-use embedded_hal::blocking::{
-    delay::DelayMs,
-    i2c::{Read, Write, WriteRead},
-};
+use embedded_hal::{delay::DelayNs, i2c::I2c};
 use sensirion_i2c::i2c;
 
 const RESPONSE_LEN: usize = 6;
@@ -46,10 +43,10 @@ impl From<Precision> for Command {
     }
 }
 
-impl<I, D, E> Sht4x<I, D>
+impl<I, D> Sht4x<I, D>
 where
-    I: Read<Error = E> + Write<Error = E> + WriteRead<Error = E>,
-    D: DelayMs<u16>,
+    I: I2c,
+    D: DelayNs,
 {
     /// Creates a new driver instance using the given I2C bus. It configures the default I2C
     /// address 0x44 used by most family members.
@@ -89,7 +86,7 @@ where
         power: HeatingPower,
         duration: HeatingDuration,
         delay: &mut D,
-    ) -> Result<Measurement, Error<E>> {
+    ) -> Result<Measurement, Error<I::Error>> {
         let raw = self.heat_and_measure_raw(power, duration, delay)?;
 
         Ok(Measurement::from(raw))
@@ -106,7 +103,7 @@ where
         power: HeatingPower,
         duration: HeatingDuration,
         delay: &mut D,
-    ) -> Result<SensorData, Error<E>> {
+    ) -> Result<SensorData, Error<I::Error>> {
         let command = Command::from((power, duration));
 
         self.write_command_and_delay_for_execution(command, delay)?;
@@ -121,7 +118,7 @@ where
         &mut self,
         precision: Precision,
         delay: &mut D,
-    ) -> Result<Measurement, Error<E>> {
+    ) -> Result<Measurement, Error<I::Error>> {
         let raw = self.measure_raw(precision, delay)?;
         Ok(Measurement::from(raw))
     }
@@ -131,7 +128,7 @@ where
         &mut self,
         precision: Precision,
         delay: &mut D,
-    ) -> Result<SensorData, Error<E>> {
+    ) -> Result<SensorData, Error<I::Error>> {
         let command = Command::from(precision);
 
         self.write_command_and_delay_for_execution(command, delay)?;
@@ -142,7 +139,7 @@ where
     }
 
     /// Reads the sensor's serial number.
-    pub fn serial_number(&mut self, delay: &mut D) -> Result<u32, Error<E>> {
+    pub fn serial_number(&mut self, delay: &mut D) -> Result<u32, Error<I::Error>> {
         self.write_command_and_delay_for_execution(Command::SerialNumber, delay)?;
         let response = self.read_response()?;
 
@@ -155,11 +152,11 @@ where
     }
 
     /// Performs a soft reset of the sensor.
-    pub fn soft_reset(&mut self, delay: &mut D) -> Result<(), Error<E>> {
+    pub fn soft_reset(&mut self, delay: &mut D) -> Result<(), Error<I::Error>> {
         self.write_command_and_delay_for_execution(Command::SoftReset, delay)
     }
 
-    fn read_response(&mut self) -> Result<[u8; RESPONSE_LEN], Error<E>> {
+    fn read_response(&mut self) -> Result<[u8; RESPONSE_LEN], Error<I::Error>> {
         let mut response = [0; RESPONSE_LEN];
 
         i2c::read_words_with_crc(&mut self.i2c, self.address.into(), &mut response)?;
@@ -178,7 +175,7 @@ where
         &mut self,
         command: Command,
         delay: &mut D,
-    ) -> Result<(), Error<E>> {
+    ) -> Result<(), Error<I::Error>> {
         let code = command.code();
 
         i2c::write_command_u8(&mut self.i2c, self.address.into(), code).map_err(Error::I2c)?;


### PR DESCRIPTION
This commit updates the library to `embedded-hal` v1.0. This was, overall, a pretty trivial update. Since this is a breaking change, I've also updated the version number to v0.2.0.